### PR TITLE
Add competition view endpoint

### DIFF
--- a/api/[action].js
+++ b/api/[action].js
@@ -8,6 +8,7 @@ const getGroups = require('../lib/get-groups');
 const getMatches = require('../lib/get-matches');
 const getPlayers = require('../lib/get-players');
 const getRanking = require('../lib/get-ranking');
+const getCompetitionView = require('../lib/get-competition-view');
 const joinCompetition = require('../lib/join-competition');
 const updateActiveCompetition = require('../lib/update-active-competition');
 const updateProfile = require('../lib/update-profile');
@@ -38,6 +39,8 @@ module.exports = (req, res) => {
       return getPlayers(req, res);
     case 'get-ranking':
       return getRanking(req, res);
+    case 'get-competition-view':
+      return getCompetitionView(req, res);
     case 'join-competition':
       return joinCompetition(req, res);
     case 'update-active-competition':

--- a/lib/get-competition-view.js
+++ b/lib/get-competition-view.js
@@ -1,0 +1,265 @@
+// /api/get-competition-view.js
+const supabase = require('../services/db');
+
+const parseCompetitionId = (value) => {
+  if (value == null) return null;
+  const parsed = Number.parseInt(Array.isArray(value) ? value[0] : value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const mapPlayerRow = (row) => {
+  const basePlayer = row?.players || {};
+
+  return {
+    playerId: row?.player_id ?? basePlayer?.id ?? null,
+    role: row?.role ?? null,
+    seed: row?.seed ?? null,
+    joinedAt: row?.joined_at || row?.created_at || null,
+    status: row?.status ?? null,
+    player: {
+      id: basePlayer?.id ?? null,
+      nickname: basePlayer?.nickname ?? null,
+      name: basePlayer?.name ?? null,
+      email: basePlayer?.email ?? null,
+      imageUrl: basePlayer?.image_url ?? null,
+    },
+  };
+};
+
+const buildPlayerMap = (players = []) => {
+  const map = new Map();
+  for (const row of players) {
+    const player = row?.player || {};
+    if (!player?.id) continue;
+    map.set(player.id, {
+      nickname: player.nickname || null,
+      name: player.name || null,
+      imageUrl: player.imageUrl || null,
+    });
+  }
+  return map;
+};
+
+const ensurePlayersFromMatches = async (matches = [], playerMap) => {
+  const missingIds = Array.from(
+    new Set(
+      matches
+        .flatMap((match) => [match.player1_id, match.player2_id])
+        .filter((id) => id && !playerMap.has(id))
+    )
+  );
+
+  if (!missingIds.length) return playerMap;
+
+  const { data: missingPlayers, error } = await supabase
+    .from('players')
+    .select('id, nickname, name, image_url')
+    .in('id', missingIds);
+
+  if (error) throw error;
+
+  for (const player of missingPlayers || []) {
+    if (!player?.id) continue;
+    playerMap.set(player.id, {
+      nickname: player.nickname || null,
+      name: player.name || null,
+      imageUrl: player.image_url || null,
+    });
+  }
+
+  return playerMap;
+};
+
+const buildStats = (matches = [], players = []) => {
+  const completedMatches = matches.filter(
+    (match) =>
+      match?.player1_score != null && match?.player2_score != null &&
+      match?.player1_score !== '' &&
+      match?.player2_score !== ''
+  );
+
+  const totalPoints = completedMatches.reduce((acc, match) => {
+    const p1 = Number(match.player1_score) || 0;
+    const p2 = Number(match.player2_score) || 0;
+    return acc + p1 + p2;
+  }, 0);
+
+  const totalSets = completedMatches.reduce((acc, match) => {
+    if (!Array.isArray(match.match_sets)) return acc;
+    return acc + match.match_sets.length;
+  }, 0);
+
+  const lastPlayedAt = completedMatches
+    .map((match) => match.date || match.created)
+    .filter(Boolean)
+    .sort((a, b) => (b || '').localeCompare(a || ''))[0] || null;
+
+  const upcomingMatches = matches.filter(
+    (match) => match?.player1_score == null && match?.player2_score == null
+  ).length;
+
+  return {
+    totalPlayers: players.length,
+    totalMatches: matches.length,
+    completedMatches: completedMatches.length,
+    upcomingMatches,
+    totalPoints,
+    totalSets,
+    lastPlayedAt,
+  };
+};
+
+const mapMatchRow = (match, playerMap) => {
+  const player1 = playerMap.get(match.player1_id) || {};
+  const player2 = playerMap.get(match.player2_id) || {};
+
+  return {
+    id: match.id,
+    date: match.date || match.created || null,
+    created: match.created || null,
+    stage: match.stage || null,
+    round: match.round || null,
+    status: match.status || null,
+    player1: {
+      id: match.player1_id || null,
+      nickname: player1.nickname || null,
+      name: player1.name || null,
+      imageUrl: player1.imageUrl || null,
+    },
+    player2: {
+      id: match.player2_id || null,
+      nickname: player2.nickname || null,
+      name: player2.name || null,
+      imageUrl: player2.imageUrl || null,
+    },
+    score:
+      match.player1_score != null && match.player2_score != null
+        ? {
+            player1: Number(match.player1_score),
+            player2: Number(match.player2_score),
+          }
+        : null,
+    matchSets: Array.isArray(match.match_sets)
+      ? match.match_sets.map((set) => ({
+          id: set.id,
+          player1Score: Number(set.player1_score),
+          player2Score: Number(set.player2_score),
+        }))
+      : [],
+  };
+};
+
+module.exports = async (req, res) => {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const competitionId = parseCompetitionId(req.query?.competitionId);
+  if (!competitionId) {
+    return res.status(400).json({ error: 'Missing competitionId parameter' });
+  }
+
+  try {
+    const { data: competition, error: competitionError } = await supabase
+      .from('competitions')
+      .select(
+        `
+        id,
+        name,
+        description,
+        status,
+        type,
+        start_date,
+        end_date,
+        created_at,
+        updated_at,
+        created_by,
+        createdBy,
+        location,
+        rules,
+        settings
+      `
+      )
+      .eq('id', competitionId)
+      .maybeSingle();
+
+    if (competitionError) throw competitionError;
+
+    if (!competition) {
+      return res.status(404).json({ error: 'Competition not found' });
+    }
+
+    const { data: playerRows, error: playersError } = await supabase
+      .from('competitions_players')
+      .select(
+        `
+        player_id,
+        role,
+        seed,
+        status,
+        joined_at,
+        created_at,
+        players (
+          id,
+          nickname,
+          name,
+          email,
+          image_url
+        )
+      `
+      )
+      .eq('competition_id', competitionId)
+      .order('joined_at', { ascending: true, nullsFirst: true });
+
+    if (playersError) throw playersError;
+
+    const players = (playerRows || []).map(mapPlayerRow);
+    let playerMap = buildPlayerMap(players);
+
+    const { data: matchesData, error: matchesError } = await supabase
+      .from('matches')
+      .select(
+        `
+        id,
+        competition_id,
+        player1_id,
+        player2_id,
+        player1_score,
+        player2_score,
+        status,
+        stage,
+        round,
+        created,
+        date,
+        match_sets (
+          id,
+          player1_score,
+          player2_score
+        )
+      `
+      )
+      .eq('competition_id', competitionId)
+      .order('date', { ascending: false, nullsFirst: false })
+      .order('created', { ascending: false, nullsFirst: false });
+
+    if (matchesError) throw matchesError;
+
+    const matches = matchesData || [];
+    playerMap = await ensurePlayersFromMatches(matches, playerMap);
+    const stats = buildStats(matches, players);
+
+    const latestMatches = matches
+      .slice(0, 10)
+      .map((match) => mapMatchRow(match, playerMap));
+
+    return res.status(200).json({
+      competition,
+      players,
+      stats,
+      latestMatches,
+    });
+  } catch (error) {
+    console.error('Error fetching competition view:', error?.message || error);
+    return res.status(500).json({ error: 'Failed to fetch competition details.' });
+  }
+};

--- a/lib/get-competition-view.js
+++ b/lib/get-competition-view.js
@@ -1,6 +1,10 @@
 // /api/get-competition-view.js
-const supabase = require('../services/db');
+const { createClient } = require('@supabase/supabase-js');
 
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_KEY
+);
 const parseCompetitionId = (value) => {
   if (value == null) return null;
   const parsed = Number.parseInt(Array.isArray(value) ? value[0] : value, 10);
@@ -12,10 +16,6 @@ const mapPlayerRow = (row) => {
 
   return {
     playerId: row?.player_id ?? basePlayer?.id ?? null,
-    role: row?.role ?? null,
-    seed: row?.seed ?? null,
-    joinedAt: row?.joined_at || row?.created_at || null,
-    status: row?.status ?? null,
     player: {
       id: basePlayer?.id ?? null,
       nickname: basePlayer?.nickname ?? null,
@@ -49,6 +49,8 @@ const ensurePlayersFromMatches = async (matches = [], playerMap) => {
     )
   );
 
+  console.log('🧩 Missing player IDs:', missingIds);
+
   if (!missingIds.length) return playerMap;
 
   const { data: missingPlayers, error } = await supabase
@@ -56,7 +58,12 @@ const ensurePlayersFromMatches = async (matches = [], playerMap) => {
     .select('id, nickname, name, image_url')
     .in('id', missingIds);
 
-  if (error) throw error;
+  if (error) {
+    console.error('❌ Error fetching missing players:', error.message);
+    throw error;
+  }
+
+  console.log('✅ Fetched missing players:', missingPlayers?.length);
 
   for (const player of missingPlayers || []) {
     if (!player?.id) continue;
@@ -135,16 +142,16 @@ const mapMatchRow = (match, playerMap) => {
     score:
       match.player1_score != null && match.player2_score != null
         ? {
-            player1: Number(match.player1_score),
-            player2: Number(match.player2_score),
-          }
+          player1: Number(match.player1_score),
+          player2: Number(match.player2_score),
+        }
         : null,
     matchSets: Array.isArray(match.match_sets)
       ? match.match_sets.map((set) => ({
-          id: set.id,
-          player1Score: Number(set.player1_score),
-          player2Score: Number(set.player2_score),
-        }))
+        id: set.id,
+        player1Score: Number(set.player1_score),
+        player2Score: Number(set.player2_score),
+      }))
       : [],
   };
 };
@@ -155,50 +162,38 @@ module.exports = async (req, res) => {
   }
 
   const competitionId = parseCompetitionId(req.query?.competitionId);
+  console.log('🏁 Incoming request for competitionId:', competitionId);
+
   if (!competitionId) {
     return res.status(400).json({ error: 'Missing competitionId parameter' });
   }
 
   try {
+    console.log('🏷️ Final competitionId used in query:', competitionId, typeof competitionId);
+    console.log('📦 Fetching competition data...');
     const { data: competition, error: competitionError } = await supabase
       .from('competitions')
-      .select(
-        `
-        id,
-        name,
-        description,
-        status,
-        type,
-        start_date,
-        end_date,
-        created_at,
-        updated_at,
-        created_by,
-        createdBy,
-        location,
-        rules,
-        settings
-      `
-      )
+      .select('id, name, type, start_date, end_date, updated_at, created_by')
       .eq('id', competitionId)
       .maybeSingle();
 
-    if (competitionError) throw competitionError;
+    if (competitionError) {
+      console.error('❌ Competition fetch error:', competitionError.message);
+      throw competitionError;
+    }
+
+    console.log('✅ Competition data:', competition);
 
     if (!competition) {
+      console.warn('⚠️ Competition not found for ID:', competitionId);
       return res.status(404).json({ error: 'Competition not found' });
     }
 
+    console.log('👥 Fetching players for competition...');
     const { data: playerRows, error: playersError } = await supabase
       .from('competitions_players')
-      .select(
-        `
+      .select(`
         player_id,
-        role,
-        seed,
-        status,
-        joined_at,
-        created_at,
         players (
           id,
           nickname,
@@ -206,51 +201,58 @@ module.exports = async (req, res) => {
           email,
           image_url
         )
-      `
-      )
+      `)
       .eq('competition_id', competitionId)
-      .order('joined_at', { ascending: true, nullsFirst: true });
+      .order('id', { ascending: true, nullsFirst: true });
 
-    if (playersError) throw playersError;
+    if (playersError) {
+      console.error('❌ Players fetch error:', playersError.message);
+      throw playersError;
+    }
+
+    console.log('✅ Players fetched:', playerRows?.length);
 
     const players = (playerRows || []).map(mapPlayerRow);
     let playerMap = buildPlayerMap(players);
 
+    console.log('🎯 Fetching matches...');
     const { data: matchesData, error: matchesError } = await supabase
       .from('matches')
-      .select(
-        `
+      .select(`
         id,
         competition_id,
         player1_id,
         player2_id,
         player1_score,
         player2_score,
-        status,
-        stage,
-        round,
-        created,
         date,
         match_sets (
           id,
           player1_score,
           player2_score
         )
-      `
-      )
+      `)
       .eq('competition_id', competitionId)
       .order('date', { ascending: false, nullsFirst: false })
       .order('created', { ascending: false, nullsFirst: false });
 
-    if (matchesError) throw matchesError;
+    if (matchesError) {
+      console.error('❌ Matches fetch error:', matchesError.message);
+      throw matchesError;
+    }
+
+    console.log('✅ Matches fetched:', matchesData?.length);
 
     const matches = matchesData || [];
     playerMap = await ensurePlayersFromMatches(matches, playerMap);
-    const stats = buildStats(matches, players);
 
+    const stats = buildStats(matches, players);
     const latestMatches = matches
       .slice(0, 10)
       .map((match) => mapMatchRow(match, playerMap));
+
+    console.log('📊 Stats built:', stats);
+    console.log('🕹️ Returning latest matches:', latestMatches.length);
 
     return res.status(200).json({
       competition,
@@ -259,7 +261,8 @@ module.exports = async (req, res) => {
       latestMatches,
     });
   } catch (error) {
-    console.error('Error fetching competition view:', error?.message || error);
+    console.error('🔥 Error fetching competition view:', error?.message || error);
+    console.error('Stack trace:', error?.stack);
     return res.status(500).json({ error: 'Failed to fetch competition details.' });
   }
 };


### PR DESCRIPTION
## Summary
- add a Supabase-backed `get-competition-view` endpoint that gathers competition details, enrolled players, stats, and recent matches
- expose the new endpoint through the action router

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eed455ecb88322919ac7174f809c4c