### PR TITLE
Add dynamic knockout slot assignment for new players

### DIFF
--- a/lib/add-players.js
+++ b/lib/add-players.js
@@ -68,6 +68,144 @@ async function upsertGroups(competitionId, maxPlayers = 4) {
   }
 }
 
+function getKnockoutStageName(totalPlayers, roundIndex = 0) {
+  const stageNames = [
+    'one_sixty_fourth_finals',
+    'one_thirty_second_finals',
+    'one_sixteenth_finals',
+    'one_eighth_finals',
+    'quarterfinals',
+    'semifinals',
+    'final',
+  ];
+
+  const sanitizedPlayers = Number.isFinite(totalPlayers) ? totalPlayers : 0;
+  const effectivePlayers = Math.max(sanitizedPlayers, 2);
+  const totalRounds = Math.ceil(Math.log2(effectivePlayers));
+  const startIndex = Math.max(0, stageNames.length - totalRounds);
+  const index = startIndex + roundIndex;
+
+  return stageNames[index] || `round_${roundIndex + 1}`;
+}
+
+async function cleanEmptyKnockoutMatches(competitionId) {
+  try {
+    const { data: deleted, error } = await supabase
+      .from('knockout_matches')
+      .delete()
+      .eq('competition_id', competitionId)
+      .is('player1_id', null)
+      .is('player2_id', null)
+      .is('winner_id', null)
+      .is('match_id', null)
+      .select('id');
+
+    if (error) {
+      throw error;
+    }
+
+    if (deleted?.length) {
+      console.log(`🧹 Rimossi ${deleted.length} match knockout vuoti per competizione ${competitionId}`);
+    }
+  } catch (err) {
+    console.error('❌ Errore durante cleanEmptyKnockoutMatches:', err.message);
+  }
+}
+
+async function fillEmptyKnockoutSlots(competitionId, newPlayerIds = []) {
+  if (!Array.isArray(newPlayerIds) || newPlayerIds.length === 0) {
+    return;
+  }
+
+  const { data: matches, error } = await supabase
+    .from('knockout_matches')
+    .select('id, player1_id, player2_id, round_order, round_name')
+    .eq('competition_id', competitionId)
+    .is('winner_id', null)
+    .order('round_order', { ascending: true })
+    .order('id', { ascending: true });
+
+  if (error) {
+    console.error('❌ Errore recuperando match knockout aperti:', error.message);
+    return;
+  }
+
+  const openMatches = matches ? [...matches] : [];
+  const leftovers = [];
+
+  for (const playerId of newPlayerIds) {
+    if (!playerId) continue;
+
+    const targetMatch = openMatches.find(match => !match.player1_id || !match.player2_id);
+
+    if (!targetMatch) {
+      leftovers.push(playerId);
+      continue;
+    }
+
+    const slot = targetMatch.player1_id ? 'player2_id' : 'player1_id';
+
+    const { error: updateError } = await supabase
+      .from('knockout_matches')
+      .update({ [slot]: playerId })
+      .eq('id', targetMatch.id)
+      .eq('competition_id', competitionId);
+
+    if (updateError) {
+      console.error(`❌ Errore assegnando il giocatore ${playerId} al match ${targetMatch.id}:`, updateError.message);
+      leftovers.push(playerId);
+    } else {
+      console.log(`✅ Assegnato giocatore ${playerId} allo slot ${slot} del match ${targetMatch.id}`);
+      targetMatch[slot] = playerId;
+    }
+  }
+
+  if (leftovers.length) {
+    const { data: firstRoundMatches, error: firstRoundErr } = await supabase
+      .from('knockout_matches')
+      .select('id, round_name')
+      .eq('competition_id', competitionId)
+      .eq('round_order', 1);
+
+    if (firstRoundErr) {
+      console.error('❌ Errore recuperando i match del primo round:', firstRoundErr.message);
+    }
+
+    const existingFirstRoundPlayers = (firstRoundMatches?.length ?? 0) * 2;
+    const totalPlayers = existingFirstRoundPlayers + leftovers.length;
+    const roundName = firstRoundMatches?.find(match => match.round_name)?.round_name
+      ?? getKnockoutStageName(totalPlayers, 0);
+
+    const payload = [];
+    for (let i = 0; i < leftovers.length; i += 2) {
+      payload.push({
+        competition_id: competitionId,
+        round_order: 1,
+        round_name: roundName,
+        player1_id: leftovers[i] ?? null,
+        player2_id: leftovers[i + 1] ?? null,
+      });
+    }
+
+    if (payload.length) {
+      const { data: inserted, error: insertErr } = await supabase
+        .from('knockout_matches')
+        .insert(payload)
+        .select('id, player1_id, player2_id');
+
+      if (insertErr) {
+        console.error('❌ Errore creando nuovi match knockout:', insertErr.message);
+      } else {
+        inserted?.forEach(row => {
+          console.log(`🆕 Creato match knockout ${row.id} con giocatori ${row.player1_id ?? 'null'} e ${row.player2_id ?? 'null'}`);
+        });
+      }
+    }
+  }
+
+  await cleanEmptyKnockoutMatches(competitionId);
+}
+
 // 🔹 Endpoint
 module.exports = (req, res) => {
   applyCors(req, res, async () => {
@@ -114,6 +252,15 @@ module.exports = (req, res) => {
       if (joinErr) {
         console.error('Error inserting competition players:', joinErr);
         return res.status(400).json({ error: joinErr.message });
+      }
+
+      try {
+        await fillEmptyKnockoutSlots(
+          competitionId,
+          newPlayers.map(pl => pl.id).filter(Boolean)
+        );
+      } catch (slotErr) {
+        console.error('❌ Errore durante fillEmptyKnockoutSlots:', slotErr.message);
       }
 
       // 3) Aggiorna user_state


### PR DESCRIPTION
## Summary
- add helpers to fill empty knockout slots or create new matches for leftover players
- ensure empty knockout matches are cleaned and stage names remain consistent when expanding the bracket

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_6900d4b3f2688322974b13e2ec7dea2c