### PR TITLE
Ensure knockout bracket regenerates fully after player removal

### DIFF
--- a/lib/delete-player.js
+++ b/lib/delete-player.js
@@ -1,100 +1,67 @@
 const applyCors = require('./cors');
 const supabase = require('../services/db');
 
-// 🔹 Helpers presi da add_players
-
-function getNearestBracketSize(n) {
-    if (n < 2) return 2;
-    return Math.pow(2, Math.floor(Math.log2(n)));
+async function getNearestBracketSize(n) {
+    const total = typeof n === 'number' ? n : 0;
+    const safe = Math.max(total, 1);
+    const exponent = Math.ceil(Math.log2(safe));
+    const size = Math.pow(2, exponent);
+    return size < 2 ? 2 : size;
 }
 
-function getKnockoutStageName(totalPlayers, roundIndex) {
-    const playersInRound = totalPlayers / Math.pow(2, roundIndex);
+function getKnockoutStageName(bracketSize, roundIndex) {
+    const playersInRound = bracketSize / Math.pow(2, roundIndex);
 
     if (playersInRound <= 2) return 'final';
     if (playersInRound <= 4) return 'semifinals';
     if (playersInRound <= 8) return 'quarterfinals';
-    if (playersInRound <= 16) return 'one_eighth_finals';
-    if (playersInRound <= 32) return 'one_sixteenth_finals';
-    if (playersInRound <= 64) return 'one_thirtysecond_finals';
+    if (playersInRound <= 16) return 'round_of_16';
+    if (playersInRound <= 32) return 'round_of_32';
+    if (playersInRound <= 64) return 'round_of_64';
 
     return `round_${roundIndex + 1}`;
 }
 
-async function cleanEmptyKnockoutMatches(competitionId) {
-    console.log(`🧹 Pulizia match vuoti per competizione ${competitionId}`);
-
-    const { error } = await supabase
-        .from('knockout_matches')
-        .delete({ count: 'exact' })
-        .eq('competition_id', competitionId)
-        .is('player1_id', null)
-        .is('player2_id', null)
-        .is('winner_id', null);
-
-    if (error) {
-        console.error('❌ Errore durante la pulizia dei match vuoti:', error);
-        throw error;
-    }
-
-    console.log(`✅ Match vuoti rimossi per competizione ${competitionId}`);
-}
-
-function buildReducedKnockoutStructure(playerIds, targetBracketSize) {
-    const unique = [];
+function buildFullKnockoutStructure(playerIds, bracketSize) {
+    const uniquePlayerIds = [];
     const seen = new Set();
 
     for (const id of playerIds) {
         if (!id || seen.has(id)) continue;
         seen.add(id);
-        unique.push(id);
+        uniquePlayerIds.push(id);
     }
 
-    if (unique.length === 0) {
-        return [];
+    const effectiveBracketSize = Math.max(bracketSize || 0, 2);
+    const byesNeeded = Math.max(effectiveBracketSize - uniquePlayerIds.length, 0);
+    const seededPlayers = [...uniquePlayerIds];
+
+    for (let i = 0; i < byesNeeded; i++) {
+        seededPlayers.push(null);
     }
 
-    const bracketSize = targetBracketSize || getNearestBracketSize(unique.length);
-    const selected = unique.slice(0, bracketSize);
-
-    if (unique.length > selected.length) {
-        console.log(
-            `⚠️ Riduzione tabellone: utilizzo ${selected.length} giocatori su ${unique.length} disponibili`
-        );
-    }
-
-    const byes = bracketSize - selected.length;
-    const seededPlayers = [...selected, ...Array(byes).fill(null)];
-
-    const totalRounds = Math.log2(bracketSize);
+    const totalRounds = Math.log2(effectiveBracketSize);
     const rounds = [];
-    let matchesInRound = bracketSize / 2;
+    let matchesInRound = effectiveBracketSize / 2;
 
     for (let roundIndex = 0; roundIndex < totalRounds; roundIndex++) {
-        const roundName = getKnockoutStageName(bracketSize, roundIndex);
+        const roundName = getKnockoutStageName(effectiveBracketSize, roundIndex);
         const matches = [];
 
         for (let matchIndex = 0; matchIndex < matchesInRound; matchIndex++) {
-            const key = `R${roundIndex + 1}M${matchIndex + 1}`;
-            const player1 = roundIndex === 0 ? seededPlayers[matchIndex * 2] ?? null : null;
-            const player2 = roundIndex === 0 ? seededPlayers[matchIndex * 2 + 1] ?? null : null;
+            const baseIndex = matchIndex * 2;
+            const player1 = roundIndex === 0 ? seededPlayers[baseIndex] ?? null : null;
+            const player2 = roundIndex === 0 ? seededPlayers[baseIndex + 1] ?? null : null;
 
             matches.push({
-                key,
-                roundIndex,
-                matchIndex,
-                player1,
-                player2,
-                nextMatchKey:
-                    matchesInRound > 1
-                        ? `R${roundIndex + 2}M${Math.floor(matchIndex / 2) + 1}`
-                        : null,
+                player1_id: player1,
+                player2_id: player2,
             });
         }
 
         rounds.push({
-            name: roundName,
-            order: roundIndex + 1,
+            roundName,
+            roundOrder: roundIndex + 1,
             matches,
         });
 
@@ -103,79 +70,84 @@ function buildReducedKnockoutStructure(playerIds, targetBracketSize) {
         }
     }
 
-    console.log(
-        `🏗️ Tabellone ridotto generato con ${rounds[0]?.matches.length || 0} match nel primo round (${bracketSize} slot)`
-    );
-
     return rounds;
 }
 
-async function regenerateReducedKnockout(competitionId, playerIds, bracketSize) {
-    console.log(`♻️ Rigenerazione knockout ridotto per competizione ${competitionId}`);
+async function cleanEmptyKnockoutMatches(competitionId) {
+    console.log(`🧹 Verifica knockout corrente per competizione ${competitionId}`);
 
-    const rounds = buildReducedKnockoutStructure(playerIds, bracketSize);
+    const { data, error } = await supabase
+        .from('knockout_matches')
+        .select('id, winner_id')
+        .eq('competition_id', competitionId);
 
-    if (!rounds.length) {
-        console.log('⚠️ Nessun giocatore sufficiente per rigenerare il knockout.');
+    if (error) {
+        console.error('❌ Errore durante la lettura dei match knockout:', error);
+        throw error;
+    }
+
+    if (!data?.length) {
+        console.log('ℹ️ Nessun match knockout presente da rimuovere.');
+        return { hasWinners: false, removedMatches: false };
+    }
+
+    const hasWinners = data.some((match) => match.winner_id !== null);
+
+    if (hasWinners) {
+        console.log('⚠️ Vincitori già registrati: salta la cancellazione dei match knockout.');
+        return { hasWinners: true, removedMatches: false };
+    }
+
+    const { error: deleteErr } = await supabase
+        .from('knockout_matches')
+        .delete()
+        .eq('competition_id', competitionId);
+
+    if (deleteErr) {
+        console.error('❌ Errore durante la cancellazione dei match knockout:', deleteErr);
+        throw deleteErr;
+    }
+
+    console.log(`🧼 Knockout precedente cancellato (nessun vincitore registrato).`);
+    return { hasWinners: false, removedMatches: true };
+}
+
+async function regenerateKnockout(competitionId, playerIds, bracketSize) {
+    const { hasWinners } = await cleanEmptyKnockoutMatches(competitionId);
+
+    if (hasWinners) {
+        console.log('⚠️ Rigenerazione completa annullata per preservare i risultati esistenti.');
         return;
     }
 
-    const storedMatches = [];
+    const rounds = buildFullKnockoutStructure(playerIds, bracketSize);
+    const roundNames = rounds.map((round) => round.roundName).join(' → ');
+
+    console.log(`🎯 Bracket generato: ${bracketSize} slot, ${rounds.length} round totali`);
+    if (roundNames) {
+        console.log(`🏗️ Tabellone completo ricreato (rounds: ${roundNames})`);
+    }
 
     for (const round of rounds) {
         const payload = round.matches.map((match) => ({
             competition_id: competitionId,
-            round_name: round.name,
-            round_order: round.order,
-            player1_id: match.player1 ?? null,
-            player2_id: match.player2 ?? null,
+            round_name: round.roundName,
+            round_order: round.roundOrder,
+            player1_id: match.player1_id,
+            player2_id: match.player2_id,
         }));
+
+        console.log(`⚙️ Round: ${round.roundName}, match generati: ${payload.length}`);
 
         if (!payload.length) continue;
 
-        const { data: inserted, error } = await supabase
-            .from('knockout_matches')
-            .insert(payload)
-            .select('id');
+        const { error } = await supabase.from('knockout_matches').insert(payload);
 
         if (error) {
-            console.error('❌ Errore durante l\'inserimento dei match rigenerati:', error);
-            throw error;
-        }
-
-        inserted.forEach((row, idx) => {
-            const match = round.matches[idx];
-            match.id = row.id;
-            storedMatches.push(match);
-        });
-    }
-
-    const linkUpdates = storedMatches
-        .filter((match) => match.nextMatchKey)
-        .map((match) => {
-            const next = storedMatches.find((m) => m.key === match.nextMatchKey);
-            return next
-                ? {
-                    id: match.id,
-                    competition_id: competitionId,
-                    next_match_id: next.id,
-                }
-                : null;
-        })
-        .filter(Boolean);
-
-    if (linkUpdates.length) {
-        const { error } = await supabase
-            .from('knockout_matches')
-            .upsert(linkUpdates, { onConflict: 'id' });
-
-        if (error) {
-            console.error('❌ Errore durante il linking dei match rigenerati:', error);
+            console.error('❌ Errore durante l\'inserimento dei match knockout:', error);
             throw error;
         }
     }
-
-    console.log(`✅ Knockout ridotto rigenerato per competizione ${competitionId}`);
 }
 
 async function createGroups(competitionId, players, maxPlayers) {
@@ -303,60 +275,11 @@ module.exports = (req, res) => {
 
             // 🔄 Gestione knockout dopo rimozione giocatore
             const totalPlayers = remainingPlayerIds.length;
-            console.log(
-                `📊 Giocatori rimasti nella competizione ${competitionId}: ${totalPlayers}`
-            );
+            console.log(`📊 Giocatori rimasti: ${totalPlayers}`);
 
-            const { data: knockoutMatches, error: knockoutErr } = await supabase
-                .from('knockout_matches')
-                .select('id, round_order, player1_id, player2_id, winner_id')
-                .eq('competition_id', competitionId);
-
-            if (knockoutErr) throw knockoutErr;
-
-            if (knockoutMatches?.length) {
-                const firstRoundOrder = knockoutMatches.reduce((min, match) => {
-                    if (match.round_order == null) return min;
-                    return Math.min(min, match.round_order);
-                }, Infinity);
-
-                const firstRoundMatches = knockoutMatches.filter(
-                    (match) => match.round_order === firstRoundOrder
-                );
-
-                const currentBracketSize = firstRoundMatches.length * 2;
-                const newBracketSize = getNearestBracketSize(totalPlayers);
-
-                console.log(
-                    `🎯 Bracket attuale: ${currentBracketSize} | Nuova dimensione suggerita: ${newBracketSize}`
-                );
-
-                const hasWinners = knockoutMatches.some((match) => match.winner_id);
-
-                if (newBracketSize < currentBracketSize && totalPlayers >= 2) {
-                    if (hasWinners) {
-                        console.log(
-                            '⚠️ Match con vincitore presenti: salto la rigenerazione per evitare perdita di dati.'
-                        );
-                        await cleanEmptyKnockoutMatches(competitionId);
-                    } else {
-                        console.log('🧨 Riduzione tabellone knockout in corso...');
-                        const { error: deleteErr } = await supabase
-                            .from('knockout_matches')
-                            .delete()
-                            .eq('competition_id', competitionId);
-
-                        if (deleteErr) throw deleteErr;
-
-                        await regenerateReducedKnockout(
-                            competitionId,
-                            remainingPlayerIds,
-                            newBracketSize
-                        );
-                    }
-                } else {
-                    await cleanEmptyKnockoutMatches(competitionId);
-                }
+            if (competition?.type === 'elimination' || competition?.type === 'group_knockout') {
+                const bracketSize = await getNearestBracketSize(totalPlayers);
+                await regenerateKnockout(competitionId, remainingPlayerIds, bracketSize);
             }
 
             return res.status(200).json({


### PR DESCRIPTION
## Summary
- rebuild knockout helpers to always generate a complete bracket sized to the nearest power of two
- regenerate knockout matches from scratch for elimination and group_knockout competitions while preserving recorded winners
- log bracket regeneration steps with detailed round information

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900f431070c8322821f9d8e94ebc8d0