### PR TITLE
Implement robust knockout slot management

### DIFF
--- a/lib/add-players.js
+++ b/lib/add-players.js
@@ -88,30 +88,6 @@ function getKnockoutStageName(totalPlayers, roundIndex = 0) {
   return stageNames[index] || `round_${roundIndex + 1}`;
 }
 
-async function cleanEmptyKnockoutMatches(competitionId) {
-  try {
-    const { data: deleted, error } = await supabase
-      .from('knockout_matches')
-      .delete()
-      .eq('competition_id', competitionId)
-      .is('player1_id', null)
-      .is('player2_id', null)
-      .is('winner_id', null)
-      .is('match_id', null)
-      .select('id');
-
-    if (error) {
-      throw error;
-    }
-
-    if (deleted?.length) {
-      console.log(`🧹 Rimossi ${deleted.length} match knockout vuoti per competizione ${competitionId}`);
-    }
-  } catch (err) {
-    console.error('❌ Errore durante cleanEmptyKnockoutMatches:', err.message);
-  }
-}
-
 async function fillEmptyKnockoutSlots(competitionId, newPlayerIds = []) {
   const players = Array.isArray(newPlayerIds)
     ? newPlayerIds.filter(Boolean)
@@ -220,8 +196,6 @@ async function fillEmptyKnockoutSlots(competitionId, newPlayerIds = []) {
       );
     });
   }
-
-  await cleanEmptyKnockoutMatches(competitionId);
 }
 
 // 🔹 Endpoint

--- a/lib/add-players.js
+++ b/lib/add-players.js
@@ -113,7 +113,11 @@ async function cleanEmptyKnockoutMatches(competitionId) {
 }
 
 async function fillEmptyKnockoutSlots(competitionId, newPlayerIds = []) {
-  if (!Array.isArray(newPlayerIds) || newPlayerIds.length === 0) {
+  const players = Array.isArray(newPlayerIds)
+    ? newPlayerIds.filter(Boolean)
+    : [newPlayerIds].filter(Boolean);
+
+  if (!players.length) {
     return;
   }
 
@@ -126,57 +130,70 @@ async function fillEmptyKnockoutSlots(competitionId, newPlayerIds = []) {
     .order('id', { ascending: true });
 
   if (error) {
-    console.error('❌ Errore recuperando match knockout aperti:', error.message);
-    return;
+    console.error('❌ Errore recuperando match knockout:', error.message);
+    throw error;
   }
 
-  const openMatches = matches ? [...matches] : [];
+  const orderedMatches = matches ? [...matches] : [];
   const leftovers = [];
 
-  for (const playerId of newPlayerIds) {
-    if (!playerId) continue;
+  for (const playerId of players) {
+    let assigned = false;
 
-    const targetMatch = openMatches.find(match => !match.player1_id || !match.player2_id);
+    for (const match of orderedMatches) {
+      if (!match.player1_id) {
+        const { error: updateErr } = await supabase
+          .from('knockout_matches')
+          .update({ player1_id: playerId })
+          .eq('competition_id', competitionId)
+          .eq('id', match.id);
 
-    if (!targetMatch) {
-      leftovers.push(playerId);
-      continue;
+        if (updateErr) {
+          console.error(`❌ Errore assegnando il giocatore ${playerId} allo slot player1_id del match ${match.id}:`, updateErr.message);
+        } else {
+          console.log(`🧩 Player ${playerId} added to match ${match.id} slot player1_id`);
+          match.player1_id = playerId;
+          assigned = true;
+        }
+        break;
+      }
+
+      if (!match.player2_id) {
+        const { error: updateErr } = await supabase
+          .from('knockout_matches')
+          .update({ player2_id: playerId })
+          .eq('competition_id', competitionId)
+          .eq('id', match.id);
+
+        if (updateErr) {
+          console.error(`❌ Errore assegnando il giocatore ${playerId} allo slot player2_id del match ${match.id}:`, updateErr.message);
+        } else {
+          console.log(`🧩 Player ${playerId} added to match ${match.id} slot player2_id`);
+          match.player2_id = playerId;
+          assigned = true;
+        }
+        break;
+      }
     }
 
-    const slot = targetMatch.player1_id ? 'player2_id' : 'player1_id';
-
-    const { error: updateError } = await supabase
-      .from('knockout_matches')
-      .update({ [slot]: playerId })
-      .eq('id', targetMatch.id)
-      .eq('competition_id', competitionId);
-
-    if (updateError) {
-      console.error(`❌ Errore assegnando il giocatore ${playerId} al match ${targetMatch.id}:`, updateError.message);
+    if (!assigned) {
       leftovers.push(playerId);
-    } else {
-      console.log(`✅ Assegnato giocatore ${playerId} allo slot ${slot} del match ${targetMatch.id}`);
-      targetMatch[slot] = playerId;
+      console.log(`⏭️ Nessuno slot libero trovato per il giocatore ${playerId}, verrà creato un nuovo match.`);
     }
   }
 
   if (leftovers.length) {
-    const { data: firstRoundMatches, error: firstRoundErr } = await supabase
-      .from('knockout_matches')
-      .select('id, round_name')
-      .eq('competition_id', competitionId)
-      .eq('round_order', 1);
+    const firstRoundMatches = orderedMatches.filter(match => match.round_order === 1);
+    const existingRoundName = firstRoundMatches.find(match => match.round_name)?.round_name;
+    const filledFirstRoundSlots = firstRoundMatches.reduce((acc, match) => {
+      return acc + (match.player1_id ? 1 : 0) + (match.player2_id ? 1 : 0);
+    }, 0);
 
-    if (firstRoundErr) {
-      console.error('❌ Errore recuperando i match del primo round:', firstRoundErr.message);
-    }
-
-    const existingFirstRoundPlayers = (firstRoundMatches?.length ?? 0) * 2;
-    const totalPlayers = existingFirstRoundPlayers + leftovers.length;
-    const roundName = firstRoundMatches?.find(match => match.round_name)?.round_name
-      ?? getKnockoutStageName(totalPlayers, 0);
+    const totalPlayers = filledFirstRoundSlots + leftovers.length;
+    const roundName = existingRoundName ?? getKnockoutStageName(totalPlayers, 0);
 
     const payload = [];
+
     for (let i = 0; i < leftovers.length; i += 2) {
       payload.push({
         competition_id: competitionId,
@@ -187,20 +204,21 @@ async function fillEmptyKnockoutSlots(competitionId, newPlayerIds = []) {
       });
     }
 
-    if (payload.length) {
-      const { data: inserted, error: insertErr } = await supabase
-        .from('knockout_matches')
-        .insert(payload)
-        .select('id, player1_id, player2_id');
+    const { data: inserted, error: insertErr } = await supabase
+      .from('knockout_matches')
+      .insert(payload)
+      .select('id, player1_id, player2_id');
 
-      if (insertErr) {
-        console.error('❌ Errore creando nuovi match knockout:', insertErr.message);
-      } else {
-        inserted?.forEach(row => {
-          console.log(`🆕 Creato match knockout ${row.id} con giocatori ${row.player1_id ?? 'null'} e ${row.player2_id ?? 'null'}`);
-        });
-      }
+    if (insertErr) {
+      console.error('❌ Errore creando nuovi match knockout:', insertErr.message);
+      throw insertErr;
     }
+
+    inserted?.forEach(row => {
+      console.log(
+        `🆕 Creato match knockout ${row.id} per competizione ${competitionId} con player1 ${row.player1_id ?? 'null'} e player2 ${row.player2_id ?? 'null'}`
+      );
+    });
   }
 
   await cleanEmptyKnockoutMatches(competitionId);
@@ -254,15 +272,6 @@ module.exports = (req, res) => {
         return res.status(400).json({ error: joinErr.message });
       }
 
-      try {
-        await fillEmptyKnockoutSlots(
-          competitionId,
-          newPlayers.map(pl => pl.id).filter(Boolean)
-        );
-      } catch (slotErr) {
-        console.error('❌ Errore durante fillEmptyKnockoutSlots:', slotErr.message);
-      }
-
       // 3) Aggiorna user_state
       const { error: stateErr } = await supabase
         .from('user_state')
@@ -290,13 +299,12 @@ module.exports = (req, res) => {
         .eq('id', competitionId)
         .single();
 
-      if (competitionType?.type === 'elimination') {
-        // estrai solo gli ID dei nuovi player
+      const normalizedType = (competitionType?.type || '').toLowerCase();
+      if (['elimination', 'group_knockout'].includes(normalizedType)) {
         const newPlayerIds = newPlayers.map(p => p.id);
 
         try {
           await fillEmptyKnockoutSlots(competitionId, newPlayerIds);
-          console.log(`🧩 Added players ${newPlayerIds.join(', ')} to knockout slots.`);
         } catch (slotErr) {
           console.error('Error filling knockout slots:', slotErr);
         }
@@ -314,23 +322,3 @@ module.exports = (req, res) => {
     }
   });
 };
-
-async function fillEmptyKnockoutSlots(competitionId, newPlayerIds) {
-  const { data: matches } = await supabase
-    .from('knockout_matches')
-    .select('id, player1_id, player2_id')
-    .eq('competition_id', competitionId)
-    .is('winner_id', null)
-    .order('id');
-
-  for (const id of newPlayerIds) {
-    const match = matches.find(m => !m.player1_id || !m.player2_id);
-    if (!match) break;
-
-    const update = match.player1_id
-      ? { player2_id: id }
-      : { player1_id: id };
-
-    await supabase.from('knockout_matches').update(update).eq('id', match.id);
-  }
-}

--- a/lib/delete-player.js
+++ b/lib/delete-player.js
@@ -1,181 +1,78 @@
 const applyCors = require('./cors');
 const supabase = require('../services/db');
 
-// 🔹 Helpers presi da add_players
+// 🔹 Helpers
 
-function getNearestBracketSize(n) {
-    if (n < 2) return 2;
-    return Math.pow(2, Math.floor(Math.log2(n)));
-}
+async function releaseKnockoutSlots(competitionId, playerIds = []) {
+    const targets = Array.isArray(playerIds)
+        ? playerIds.filter(Boolean)
+        : [playerIds].filter(Boolean);
 
-function getKnockoutStageName(totalPlayers, roundIndex) {
-    const playersInRound = totalPlayers / Math.pow(2, roundIndex);
-
-    if (playersInRound <= 2) return 'final';
-    if (playersInRound <= 4) return 'semifinals';
-    if (playersInRound <= 8) return 'quarterfinals';
-    if (playersInRound <= 16) return 'one_eighth_finals';
-    if (playersInRound <= 32) return 'one_sixteenth_finals';
-    if (playersInRound <= 64) return 'one_thirtysecond_finals';
-
-    return `round_${roundIndex + 1}`;
-}
-
-async function cleanEmptyKnockoutMatches(competitionId) {
-    console.log(`🧹 Pulizia match vuoti per competizione ${competitionId}`);
-
-    const { error } = await supabase
-        .from('knockout_matches')
-        .delete({ count: 'exact' })
-        .eq('competition_id', competitionId)
-        .is('player1_id', null)
-        .is('player2_id', null)
-        .is('winner_id', null);
-
-    if (error) {
-        console.error('❌ Errore durante la pulizia dei match vuoti:', error);
-        throw error;
-    }
-
-    console.log(`✅ Match vuoti rimossi per competizione ${competitionId}`);
-}
-
-function buildReducedKnockoutStructure(playerIds, targetBracketSize) {
-    const unique = [];
-    const seen = new Set();
-
-    for (const id of playerIds) {
-        if (!id || seen.has(id)) continue;
-        seen.add(id);
-        unique.push(id);
-    }
-
-    if (unique.length === 0) {
-        return [];
-    }
-
-    const bracketSize = targetBracketSize || getNearestBracketSize(unique.length);
-    const selected = unique.slice(0, bracketSize);
-
-    if (unique.length > selected.length) {
-        console.log(
-            `⚠️ Riduzione tabellone: utilizzo ${selected.length} giocatori su ${unique.length} disponibili`
-        );
-    }
-
-    const byes = bracketSize - selected.length;
-    const seededPlayers = [...selected, ...Array(byes).fill(null)];
-
-    const totalRounds = Math.log2(bracketSize);
-    const rounds = [];
-    let matchesInRound = bracketSize / 2;
-
-    for (let roundIndex = 0; roundIndex < totalRounds; roundIndex++) {
-        const roundName = getKnockoutStageName(bracketSize, roundIndex);
-        const matches = [];
-
-        for (let matchIndex = 0; matchIndex < matchesInRound; matchIndex++) {
-            const key = `R${roundIndex + 1}M${matchIndex + 1}`;
-            const player1 = roundIndex === 0 ? seededPlayers[matchIndex * 2] ?? null : null;
-            const player2 = roundIndex === 0 ? seededPlayers[matchIndex * 2 + 1] ?? null : null;
-
-            matches.push({
-                key,
-                roundIndex,
-                matchIndex,
-                player1,
-                player2,
-                nextMatchKey:
-                    matchesInRound > 1
-                        ? `R${roundIndex + 2}M${Math.floor(matchIndex / 2) + 1}`
-                        : null,
-            });
-        }
-
-        rounds.push({
-            name: roundName,
-            order: roundIndex + 1,
-            matches,
-        });
-
-        if (roundIndex < totalRounds - 1) {
-            matchesInRound = Math.floor(matchesInRound / 2);
-        }
-    }
-
-    console.log(
-        `🏗️ Tabellone ridotto generato con ${rounds[0]?.matches.length || 0} match nel primo round (${bracketSize} slot)`
-    );
-
-    return rounds;
-}
-
-async function regenerateReducedKnockout(competitionId, playerIds, bracketSize) {
-    console.log(`♻️ Rigenerazione knockout ridotto per competizione ${competitionId}`);
-
-    const rounds = buildReducedKnockoutStructure(playerIds, bracketSize);
-
-    if (!rounds.length) {
-        console.log('⚠️ Nessun giocatore sufficiente per rigenerare il knockout.');
+    if (!targets.length) {
         return;
     }
 
-    const storedMatches = [];
-
-    for (const round of rounds) {
-        const payload = round.matches.map((match) => ({
-            competition_id: competitionId,
-            round_name: round.name,
-            round_order: round.order,
-            player1_id: match.player1 ?? null,
-            player2_id: match.player2 ?? null,
-        }));
-
-        if (!payload.length) continue;
-
-        const { data: inserted, error } = await supabase
+    for (const playerId of targets) {
+        const { data: matches, error } = await supabase
             .from('knockout_matches')
-            .insert(payload)
-            .select('id');
+            .select('id, player1_id, player2_id')
+            .eq('competition_id', competitionId)
+            .or(`player1_id.eq.${playerId},player2_id.eq.${playerId}`);
 
         if (error) {
-            console.error('❌ Errore durante l\'inserimento dei match rigenerati:', error);
-            throw error;
+            console.error(
+                `❌ Errore recuperando match knockout per il giocatore ${playerId} nella competizione ${competitionId}:`,
+                error.message
+            );
+            continue;
         }
 
-        inserted.forEach((row, idx) => {
-            const match = round.matches[idx];
-            match.id = row.id;
-            storedMatches.push(match);
-        });
-    }
+        if (!matches?.length) {
+            console.log(
+                `ℹ️ Nessun match knockout da aggiornare per il giocatore ${playerId} nella competizione ${competitionId}`
+            );
+            continue;
+        }
 
-    const linkUpdates = storedMatches
-        .filter((match) => match.nextMatchKey)
-        .map((match) => {
-            const next = storedMatches.find((m) => m.key === match.nextMatchKey);
-            return next
-                ? {
-                    id: match.id,
-                    competition_id: competitionId,
-                    next_match_id: next.id,
-                }
-                : null;
-        })
-        .filter(Boolean);
+        for (const match of matches) {
+            const slotsToClear = [];
 
-    if (linkUpdates.length) {
-        const { error } = await supabase
-            .from('knockout_matches')
-            .upsert(linkUpdates, { onConflict: 'id' });
+            if (match.player1_id === playerId) {
+                slotsToClear.push('player1_id');
+            }
 
-        if (error) {
-            console.error('❌ Errore durante il linking dei match rigenerati:', error);
-            throw error;
+            if (match.player2_id === playerId) {
+                slotsToClear.push('player2_id');
+            }
+
+            if (!slotsToClear.length) {
+                continue;
+            }
+
+            const payload = {};
+            slotsToClear.forEach((slot) => {
+                payload[slot] = null;
+            });
+
+            const { error: updateErr } = await supabase
+                .from('knockout_matches')
+                .update(payload)
+                .eq('competition_id', competitionId)
+                .eq('id', match.id);
+
+            if (updateErr) {
+                console.error(
+                    `❌ Errore aggiornando il match ${match.id} per rimuovere il giocatore ${playerId}:`,
+                    updateErr.message
+                );
+                continue;
+            }
+
+            slotsToClear.forEach((slot) => {
+                console.log(`🧼 Player ${playerId} removed from match ${match.id} slot ${slot}`);
+            });
         }
     }
-
-    console.log(`✅ Knockout ridotto rigenerato per competizione ${competitionId}`);
 }
 
 async function createGroups(competitionId, players, maxPlayers) {
@@ -301,62 +198,9 @@ module.exports = (req, res) => {
                 }
             }
 
-            // 🔄 Gestione knockout dopo rimozione giocatore
-            const totalPlayers = remainingPlayerIds.length;
-            console.log(
-                `📊 Giocatori rimasti nella competizione ${competitionId}: ${totalPlayers}`
-            );
-
-            const { data: knockoutMatches, error: knockoutErr } = await supabase
-                .from('knockout_matches')
-                .select('id, round_order, player1_id, player2_id, winner_id')
-                .eq('competition_id', competitionId);
-
-            if (knockoutErr) throw knockoutErr;
-
-            if (knockoutMatches?.length) {
-                const firstRoundOrder = knockoutMatches.reduce((min, match) => {
-                    if (match.round_order == null) return min;
-                    return Math.min(min, match.round_order);
-                }, Infinity);
-
-                const firstRoundMatches = knockoutMatches.filter(
-                    (match) => match.round_order === firstRoundOrder
-                );
-
-                const currentBracketSize = firstRoundMatches.length * 2;
-                const newBracketSize = getNearestBracketSize(totalPlayers);
-
-                console.log(
-                    `🎯 Bracket attuale: ${currentBracketSize} | Nuova dimensione suggerita: ${newBracketSize}`
-                );
-
-                const hasWinners = knockoutMatches.some((match) => match.winner_id);
-
-                if (newBracketSize < currentBracketSize && totalPlayers >= 2) {
-                    if (hasWinners) {
-                        console.log(
-                            '⚠️ Match con vincitore presenti: salto la rigenerazione per evitare perdita di dati.'
-                        );
-                        await cleanEmptyKnockoutMatches(competitionId);
-                    } else {
-                        console.log('🧨 Riduzione tabellone knockout in corso...');
-                        const { error: deleteErr } = await supabase
-                            .from('knockout_matches')
-                            .delete()
-                            .eq('competition_id', competitionId);
-
-                        if (deleteErr) throw deleteErr;
-
-                        await regenerateReducedKnockout(
-                            competitionId,
-                            remainingPlayerIds,
-                            newBracketSize
-                        );
-                    }
-                } else {
-                    await cleanEmptyKnockoutMatches(competitionId);
-                }
+            const normalizedType = (competition?.type || '').toLowerCase();
+            if (['elimination', 'group_knockout'].includes(normalizedType)) {
+                await releaseKnockoutSlots(competitionId, playerId);
             }
 
             return res.status(200).json({

--- a/lib/get-knockouts.js
+++ b/lib/get-knockouts.js
@@ -77,15 +77,24 @@ module.exports = (req, res) => {
                 const removed = existingIds.filter(id => !qualifiedIds.has(id));
                 const added = Array.from(qualifiedIds).filter(id => !distinctPlayers.has(id));
 
-                if (removed.length === 0 && added.length === 0) {
+                const expectedRounds = getExpectedRoundMetadata(sanitizedQualified.length);
+                const structureMismatch = hasStructureMismatch(existing, expectedRounds);
+
+                if (!structureMismatch && removed.length === 0 && added.length === 0) {
                     // ✅ stessi giocatori — NON rigenerare
                     console.log(`✅ Knockouts già validi per competizione ${competitionId}`);
                     const rounds = groupByRound(existing);
                     return res.status(200).json({ competitionId, rounds });
                 }
 
+                if (structureMismatch) {
+                    console.log(
+                        `⚠️ Struttura knockout incompleta o non valida per competizione ${competitionId}, rigenero da zero`
+                    );
+                }
+
                 // 👇 Tolleranza piccole variazioni (es. un solo nuovo player)
-                if (added.length <= 1 && removed.length <= 1) {
+                if (!structureMismatch && added.length <= 1 && removed.length <= 1) {
                     console.log(`⚠️ Differenza minore (${added.length} aggiunti, ${removed.length} rimossi), NON rigenero`);
                     const rounds = groupByRound(existing);
                     return res.status(200).json({ competitionId, rounds });
@@ -322,3 +331,72 @@ function getKnockoutStageName(totalPlayers, roundIndex) {
         default: return `round_${roundIndex + 1}`;
     }
 }
+
+function getExpectedRoundMetadata(playerCount) {
+    if (!playerCount || playerCount < 2) return [];
+
+    const bracketSize = Math.pow(2, Math.ceil(Math.log2(Math.max(playerCount, 2))));
+    const totalRounds = Math.log2(bracketSize);
+    const rounds = [];
+    let matchesInRound = bracketSize / 2;
+
+    for (let roundIndex = 0; roundIndex < totalRounds; roundIndex++) {
+        rounds.push({
+            order: roundIndex + 1,
+            round_name: getKnockoutStageName(playerCount, roundIndex),
+            matchCount: matchesInRound,
+        });
+
+        if (roundIndex < totalRounds - 1) {
+            matchesInRound = Math.max(1, Math.floor(matchesInRound / 2));
+        }
+    }
+
+    return rounds;
+}
+
+function hasStructureMismatch(existingMatches, expectedRounds) {
+    if (!expectedRounds.length) {
+        return existingMatches && existingMatches.length > 0;
+    }
+
+    const byOrder = existingMatches.reduce((acc, match) => {
+        const key = match.round_order;
+        if (!acc.has(key)) {
+            acc.set(key, { count: 0, names: new Set() });
+        }
+        const entry = acc.get(key);
+        entry.count += 1;
+        if (match.round_name) {
+            entry.names.add(match.round_name);
+        }
+        return acc;
+    }, new Map());
+
+    for (const round of expectedRounds) {
+        const entry = byOrder.get(round.order);
+        if (!entry) {
+            return true;
+        }
+        if (entry.count < round.matchCount) {
+            return true;
+        }
+        if (entry.names.size && !entry.names.has(round.round_name)) {
+            return true;
+        }
+    }
+
+    for (const order of byOrder.keys()) {
+        if (!expectedRounds.some((round) => round.order === order)) {
+            const entry = byOrder.get(order);
+            if (entry && entry.count > 0) {
+                return true;
+            }
+        }
+    }
+
+    const expectedTotal = expectedRounds.reduce((sum, round) => sum + round.matchCount, 0);
+    const existingTotal = existingMatches.length;
+    return existingTotal < expectedTotal;
+}
+


### PR DESCRIPTION
## Summary
- fill knockout slots in order and create new opening matches with detailed logging when players join competitions
- clear only the relevant knockout slots when players leave competitions while keeping bracket integrity intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69036ead4f488322bb0b0f8a2c3f3654